### PR TITLE
Fix Windows Installation Issues

### DIFF
--- a/libraries/z_provider_mapping.rb
+++ b/libraries/z_provider_mapping.rb
@@ -14,3 +14,4 @@ Chef::Platform.set platform: :smartos, resource: :git_client, provider: Chef::Pr
 Chef::Platform.set platform: :solaris2, resource: :git_client, provider: Chef::Provider::GitClient::Package
 Chef::Platform.set platform: :suse, resource: :git_client, provider: Chef::Provider::GitClient::Package
 Chef::Platform.set platform: :ubuntu, resource: :git_client, provider: Chef::Provider::GitClient::Package
+Chef::Platform.set platform: :windows, resource: :git_client, provider: Chef::Provider::GitClient::Windows

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -29,12 +29,7 @@ when 'mac_os_x'
     action :install
   end
 when 'windows'
-  git_client 'default' do
-    windows_display_name node['git']['display_name']
-    windows_package_url node['git']['url']
-    windows_package_checksum node['git']['checksum']
-    windows_package_version node['git']['version']
-  end
+  include_recipe 'git::windows'
 else
   git_client 'default' do
     action :install

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -28,6 +28,13 @@ when 'mac_os_x'
     osx_dmg_checksum node['git']['osx_dmg']['checksum']
     action :install
   end
+when 'windows'
+  git_client 'default' do
+    windows_display_name node['git']['display_name']
+    windows_package_url node['git']['url']
+    windows_package_checksum node['git']['checksum']
+    windows_package_version node['git']['version']
+  end
 else
   git_client 'default' do
     action :install

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 
 git_client 'default' do
-  windows_display_name node['windows']['display_name']
-  windows_package_url node['windows']['url']
-  windows_package_checksum node['windows']['checksum']
+  windows_display_name node['git']['display_name']
+  windows_package_url node['git']['url']
+  windows_package_checksum node['git']['checksum']
   action :install
 end


### PR DESCRIPTION
- [ ] @someara 

This cookbook will now work with Windows.  It was missing a mapping in z_provider_mapping.rb for Chef 11 and the package recipe should execute the windows recipe if `node['platform']` is windows.