### PR TITLE
Fix tests on windows

### DIFF
--- a/test/integration/default-windows/serverspec/git_installed_windows_spec.rb
+++ b/test/integration/default-windows/serverspec/git_installed_windows_spec.rb
@@ -1,8 +1,7 @@
 require 'serverspec'
 
-set :backend, :exec
+set :backend, :cmd
 set :os, family: 'windows'
-puts "os: #{os}"
 
 PROGRAM_FILES = ENV['ProgramFiles(x86)'] || ENV['ProgramFiles']
 GIT_PATH = "#{ PROGRAM_FILES }\\Git\\Cmd"


### PR DESCRIPTION
The tests aren't working on windows right now because :exec is trying to run "/bin/sh -c git --version". This fixes that.