### PR TITLE
support 32 bit and 64 bit installs on windows

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,9 +20,14 @@
 case node['platform_family']
 when 'windows'
   default['git']['version'] = '2.7.4'
-  default['git']['architecture'] = '32'
+  if node['kernel']['machine'] == 'x86_64'
+    default['git']['architecture'] = '64'
+    default['git']['checksum'] = '1290afb22f2441ce85f8f6f1a94c06768ca470dc18113a83ef6a4cefc16c2381'
+  else
+    default['git']['architecture'] = '32'
+    default['git']['checksum'] = '49601d5102df249d6f866ecfa1eea68eb5672acc1dbb7e4051099e792f6da5fc'
+  end
   default['git']['url'] = 'https://github.com/git-for-windows/git/releases/download/v%{version}.windows.1/Git-%{version}-%{architecture}-bit.exe'
-  default['git']['checksum'] = '49601d5102df249d6f866ecfa1eea68eb5672acc1dbb7e4051099e792f6da5fc'
   default['git']['display_name'] = "Git version #{node['git']['version']}"
 when 'mac_os_x'
   default['git']['osx_dmg']['app_name']    = 'git-2.7.1-intel-universal-mavericks'

--- a/libraries/provider_git_client_windows.rb
+++ b/libraries/provider_git_client_windows.rb
@@ -17,7 +17,11 @@ class Chef
 
           # Git is installed to Program Files (x86) on 64-bit machines and
           # 'Program Files' on 32-bit machines
-          PROGRAM_FILES = ENV['ProgramFiles(x86)'] || ENV['ProgramFiles']
+          PROGRAM_FILES = if node['git']['architecture'] == '32'
+                            ENV['ProgramFiles(x86)'] || ENV['ProgramFiles']
+                          else
+                            ENV['ProgramW6432'] || ENV['ProgramFiles']
+                          end
           GIT_PATH = "#{PROGRAM_FILES}\\Git\\Cmd".freeze
 
           # COOK-3482 - windows_path resource doesn't change the current process


### PR DESCRIPTION
Fixes #91 

Default will detect the bitness of the OS and install the proper git client, but you can override if you are on a 64 bit OS but want the 32 bit client with the `node['git']['architecture']` attribute.