### PR TITLE
Add a new attribute for user group configuration

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -11,7 +11,7 @@ action :set do
     execute "#{config_cmd} #{new_resource.key} \"#{new_resource.value}\"" do
       cwd new_resource.path
       user new_resource.user
-      group new_resource.user
+      group new_resource.group
       environment cmd_env
       Chef::Log.info "#{@new_resource} created."
     end
@@ -39,7 +39,7 @@ end
 
 def config
   cmd = [config_cmd, new_resource.key].join(' ')
-  git_config = Mixlib::ShellOut.new(cmd, user: new_resource.user, group: new_resource.user, cwd: new_resource.path, env: cmd_env)
+  git_config = Mixlib::ShellOut.new(cmd, user: new_resource.user, group: new_resource.group, cwd: new_resource.path, env: cmd_env)
   Chef::Log.debug("Current config cmd: #{git_config.inspect}")
   git_config.run_command.stdout.chomp
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -6,6 +6,7 @@ attribute :value, kind_of: String, required: true
 attribute :scope, equal_to: %w(local global system), default: 'global'
 attribute :path,  kind_of: String
 attribute :user,  kind_of: String
+attribute :group, kind_of: String
 attribute :options, kind_of: String
 
 attr_accessor :exists


### PR DESCRIPTION
### Description
Add a new attribute for user group configuration

### Issues Resolved
Currently, we assume the `group` attribute inside `git_config` resource is the same as the `user` attribute. See: https://github.com/chef-cookbooks/git/blob/master/providers/config.rb#L14
This may not true for all cases. Adding this new `group` attribute, so we can pass down this config if we need to. 



