### PR TITLE
respond_to?(:chef_version) for < 12.6 compat

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -32,4 +32,4 @@ depends 'yum-epel'
 
 source_url 'https://github.com/chef-cookbooks/git'
 issues_url 'https://github.com/chef-cookbooks/git/issues'
-chef_version '>= 12.1'
+chef_version '>= 12.1' if respond_to?(:chef_version)


### PR DESCRIPTION
### Description

This PR checks if `chef_version` is defined before using it in `metadata.rb`.

### Issues Resolved

This allows Chef clients < 12.6 to use this cookbook. See:

* https://github.com/berkshelf/berkshelf/issues/1499
* https://docs.chef.io/release_notes.html#what-s-new-in-12-6

### Check List
- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
