### PR TITLE
Document installing from source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ git_client 'default' do
 end
 ```
 
+#### Example of source install
+
+```ruby
+git_client 'source' do
+  provider Chef::Provider::GitClient::Source
+  source_version '2.14.2'
+  source_checksum 'a03a12331d4f9b0f71733db9f47e1232d4ddce00e7f2a6e20f6ec9a19ce5ff61'
+  action :install
+end
+```
+
 ### git_config
 
 The `git_config` resource manages the configuration of Git client on a machine.


### PR DESCRIPTION
Fixes #106

Signed-off-by: Eric Heydrick <eheydrick@gmail.com>

### Description

Documents the usage of `git_client` when installing from source is desired

### Issues Resolved

#106

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
