### PR TITLE
Bump git version to 2.17.1

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,9 +31,9 @@ when 'windows'
   default['git']['display_name'] = "Git version #{node['git']['version']}"
 else
   default['git']['prefix'] = '/usr/local'
-  default['git']['version'] = '2.9.5'
+  default['git']['version'] = '2.17.1'
   default['git']['url'] = 'https://nodeload.github.com/git/git/tar.gz/v%{version}'
-  default['git']['checksum'] = '88995ab18154fa302478d33efa4418d354a5e592645ebef02c69b3dd76b526c1'
+  default['git']['checksum'] = '690f12cc5691e5adaf2dd390eae6f5acce68ae0d9bd9403814f8a1433833f02a'
   default['git']['use_pcre'] = false
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -20,7 +20,7 @@ module GitCookbook
 
     def parsed_source_checksum
       return new_resource.source_checksum if new_resource.source_checksum
-      '88995ab18154fa302478d33efa4418d354a5e592645ebef02c69b3dd76b526c1' # 2.9.5 tarball
+      '690f12cc5691e5adaf2dd390eae6f5acce68ae0d9bd9403814f8a1433833f02a' # 2.17.1 tarball
     end
 
     # windows


### PR DESCRIPTION
2.9.5 (probably?) suffers from [CVE-2018-11235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11235).

I have tested this on CentOS 7 but I don't have time to test every system. Perhaps this version is too new for some but we do need some kind of update to address the vulnerability.