### PR TITLE
Require Chef 14 and resolve cookstyle warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
   - INSTANCE=resources-centos-7
   - INSTANCE=resources-centos-8
   - INSTANCE=resources-fedora-latest
-  - INSTANCE=resources-opensuse-leap
+  - INSTANCE=resources-opensuse-leap-15
   - INSTANCE=source-ubuntu-1604
   - INSTANCE=source-ubuntu-1804
   - INSTANCE=source-debian-9
@@ -35,14 +35,14 @@ env:
   - INSTANCE=source-centos-7
   - INSTANCE=source-centos-8
   - INSTANCE=source-fedora-latest
-  - INSTANCE=source-opensuse-leap
+  - INSTANCE=source-opensuse-leap-15
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(chef shell-init bash)"
   - chef --version
 
-script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
+script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml CHEF_VERSION=${CHEF_VERSION} kitchen verify ${INSTANCE}
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,18 +20,20 @@ env:
   matrix:
   - INSTANCE=resources-ubuntu-1604
   - INSTANCE=resources-ubuntu-1804
-  - INSTANCE=resources-debian-8
   - INSTANCE=resources-debian-9
+  - INSTANCE=resources-debian-10
   - INSTANCE=resources-centos-6
   - INSTANCE=resources-centos-7
+  - INSTANCE=resources-centos-8
   - INSTANCE=resources-fedora-latest
   - INSTANCE=resources-opensuse-leap
   - INSTANCE=source-ubuntu-1604
   - INSTANCE=source-ubuntu-1804
-  - INSTANCE=source-debian-8
   - INSTANCE=source-debian-9
+  - INSTANCE=source-debian-10
   - INSTANCE=source-centos-6
   - INSTANCE=source-centos-7
+  - INSTANCE=source-centos-8
   - INSTANCE=source-fedora-latest
   - INSTANCE=source-opensuse-leap
 
@@ -45,7 +47,7 @@ script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
 matrix:
   include:
     - script:
-      - chef exec delivery local all
+      - delivery local all
       env:
         - UNIT_AND_LINT=1
         - CHEF_LICENSE=accept

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
     packages:
       - chef-workstation
 
-# Don't `bundle install` which takes about 1.5 mins
 install: echo "skip bundle install"
 
 env:
@@ -40,8 +39,6 @@ before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
   - eval "$(chef shell-init bash)"
   - chef --version
-  - cookstyle --version
-  - foodcritic --version
 
 script: KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen verify ${INSTANCE}
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 # This gemfile provides additional gems for testing and releasing this cookbook
-# It is meant to be installed on top of ChefDK which provides the majority
+# It is meant to be installed on top of ChefDK / Chef Workstation which provide the majority
 # of the necessary gems for testing this cookbook
 #
 # Run 'chef exec bundle install' to install these dependencies

--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ The following platforms have been tested with Test Kitchen:
 |---------------+-------|
 | centos-7      | X     |
 |---------------+-------|
-| fedora        | X     |
+| centos-8      | X     |
 |---------------+-------|
-| debian-8      | X     |
+| fedora        | X     |
 |---------------+-------|
 | debian-9      | X     |
 |---------------+-------|
-| ubuntu-14.04  | X     |
+| debian-10     | X     |
 |---------------+-------|
 | ubuntu-16.04  | X     |
+|---------------+-------|
+| ubuntu-18.04  | X     |
 |---------------+-------|
 | openSUSE Leap | X     |
 |---------------+-------|
@@ -36,11 +38,11 @@ The following platforms have been tested with Test Kitchen:
 
 ### Chef
 
-- Chef 12.7+
+- Chef 14+
 
 ### Cookbooks
 
-- 'build-essential' 5.0 or later - For compiling from source
+- none
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@
 # Cookbook:: git
 # Attributes:: default
 #
-# Copyright:: 2008-2016, Chef Software, Inc.
+# Copyright:: 2008-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/chefignore
+++ b/chefignore
@@ -45,22 +45,19 @@ a.out
 
 # Testing #
 ###########
-.watchr
 .rspec
 spec/*
 spec/fixtures/*
 test/*
 features/*
 examples/*
-Guardfile
 Procfile
-kitchen*
+.kitchen*
 .rubocop.yml
 spec/*
-Rakefile
 .travis.yml
 .foodcritic
-.codeclimate.yml
+appveyor.yml
 
 # SCM #
 #######
@@ -93,14 +90,3 @@ CONTRIBUTING*
 CHANGELOG*
 TESTING*
 
-# Strainer #
-############
-Colanderfile
-Strainerfile
-.colander
-.strainer
-
-# Vagrant #
-###########
-.vagrant
-Vagrantfile

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,6 +2,7 @@ driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_license: accept-no-persist
 
 transport:
   name: dokken
@@ -19,16 +20,16 @@ platforms:
     image: dokken/amazonlinux
     pid_one_command: /sbin/init
 
-- name: debian-8
+- name: debian-9
   driver:
-    image: dokken/debian-8
+    image: dokken/debian-9
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
-- name: debian-9
+- name: debian-10
   driver:
-    image: dokken/debian-9
+    image: dokken/debian-10
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,7 +2,6 @@ driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
-  chef_license: accept-no-persist
 
 transport:
   name: dokken
@@ -10,6 +9,7 @@ transport:
 provisioner:
   name: dokken
   deprecations_as_errors: true
+  chef_license: accept-no-persist
 
 verifier:
   name: inspec
@@ -19,6 +19,11 @@ platforms:
   driver:
     image: dokken/amazonlinux
     pid_one_command: /sbin/init
+
+- name: amazonlinux-2
+  driver:
+    image: dokken/amazonlinux-2
+    pid_one_command: /usr/lib/systemd/systemd
 
 - name: debian-9
   driver:
@@ -44,17 +49,15 @@ platforms:
     image: dokken/centos-7
     pid_one_command: /usr/lib/systemd/systemd
 
+- name: centos-8
+  driver:
+    image: dokken/centos-8
+    pid_one_command: /usr/lib/systemd/systemd
+
 - name: fedora-latest
   driver:
     image: dokken/fedora-latest
     pid_one_command: /usr/lib/systemd/systemd
-
-- name: ubuntu-14.04
-  driver:
-    image: dokken/ubuntu-14.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
 
 - name: ubuntu-16.04
   driver:
@@ -70,7 +73,7 @@ platforms:
     intermediate_instructions:
       - RUN /usr/bin/apt-get update
 
-- name: opensuse-leap
+- name: opensuse-leap-15
   driver:
-    image: dokken/opensuse-leap
+    image: dokken/opensuse-leap-15
     pid_one_command: /bin/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -13,13 +13,15 @@ platforms:
   - name: amazonlinux
     driver_config:
       box: mvbcoding/awslinux
+  - name: amazonlinux-2
   - name: centos-6
   - name: centos-7
+  - name: centos-8
   - name: debian-9
   - name: debian-10
   - name: freebsd-11
   - name: fedora-29
-  - name: opensuse-leap-42
+  - name: opensuse-leap-15
   - name: ubuntu-16.04
   - name: ubuntu-18.04
   - name: windows-2012r2

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -15,19 +15,19 @@ platforms:
       box: mvbcoding/awslinux
   - name: centos-6
   - name: centos-7
-  - name: debian-8
   - name: debian-9
+  - name: debian-10
   - name: freebsd-11
-  - name: fedora-28
+  - name: fedora-29
   - name: opensuse-leap-42
   - name: ubuntu-16.04
   - name: ubuntu-18.04
-  - name: windows-2012r2-standard
+  - name: windows-2012r2
     driver:
-      box: chef/windows-server-2012r2-standard # private box in Chef's Atlas account
+      box: tas50/windows_2012r2
   - name: windows-2016-standard
     driver:
-      box: chef/windows-server-2016-standard # private box in Chef's Atlas account
+      box: tas50/windows_2016
   - name: macos-10.12
     run_list: homebrew::default
     driver:
@@ -42,13 +42,13 @@ suites:
   run_list:
   - recipe[test::source]
   excludes:
-    - windows-2012r2-standard
+    - windows-2012r2
     - windows-2016-standard
     - macosx-1012
 - name: server
   run_list:
   - recipe[test::server]
   excludes:
-    - windows-2012r2-standard
+    - windows-2012r2
     - windows-2016-standard
     - macosx-1012

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -3,8 +3,8 @@ module GitCookbook
     # linux packages default to distro offering
     def parsed_package_name
       return new_resource.package_name if new_resource.package_name
-      return 'developer/versioning/git' if node['platform'] == 'omnios'
-      return 'scmgit' if node['platform'] == 'smartos'
+      return 'developer/versioning/git' if platform?('smartos')
+      return 'scmgit' if platform?('smartos')
       'git'
     end
 

--- a/libraries/provider_git_client.rb
+++ b/libraries/provider_git_client.rb
@@ -1,12 +1,6 @@
 class Chef
   class Provider
     class GitClient < Chef::Provider::LWRPBase
-      use_inline_resources # ~FC113
-
-      def whyrun_supported?
-        true
-      end
-
       include GitCookbook::Helpers
     end
   end

--- a/libraries/provider_git_service.rb
+++ b/libraries/provider_git_service.rb
@@ -1,19 +1,13 @@
 class Chef
   class Provider
     class GitClient < Chef::Provider::LWRPBase
-      use_inline_resources # ~FC113
-
-      def whyrun_supported?
-        true
-      end
-
       include Chef::DSL::IncludeRecipe
       include GitCookbook::Helpers
 
       provides :git_service, os: 'linux'
 
       action :create do
-        return "#{node['platform']} is not supported by the #{cookbook_name}::#{recipe_name} recipe" if node['platform'] == 'windows'
+        return "#{node['platform']} is not supported by the #{cookbook_name}::#{recipe_name} recipe" if platform?('windows')
 
         include_recipe 'git'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,11 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Installs git and/or sets up a Git server daemon'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '9.0.1'
-recipe 'git', 'Installs git'
-recipe 'git::server', 'Sets up a a git daemon'
-recipe 'git::source', 'Installs git from source'
 
 supports 'amazon'
 supports 'centos'
@@ -21,13 +17,10 @@ supports 'redhat'
 supports 'smartos'
 supports 'scientific'
 supports 'suse'
-supports 'opensuse'
 supports 'opensuseleap'
 supports 'ubuntu'
 supports 'windows'
 
-depends 'build-essential', '>= 5.0.0'
-
 source_url 'https://github.com/chef-cookbooks/git'
 issues_url 'https://github.com/chef-cookbooks/git/issues'
-chef_version '>= 12.7' if respond_to?(:chef_version)
+chef_version '>= 14'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: git
 # Recipe:: default
 #
-# Copyright:: 2008-2016, Chef Software, Inc.
+# Copyright:: 2008-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -2,7 +2,7 @@
 # Cookbook:: git
 # Recipe:: package
 #
-# Copyright:: 2008-2016, Chef Software, Inc.
+# Copyright:: 2008-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -2,7 +2,7 @@
 # Cookbook:: git
 # Recipe:: server
 #
-# Copyright:: 2009-2016, Chef Software, Inc.
+# Copyright:: 2009-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -2,7 +2,7 @@
 # Cookbook:: git
 # Recipe:: windows
 #
-# Copyright:: 2008-2016, Chef Software, Inc.
+# Copyright:: 2008-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes multiple cookstyle warnings and remove the need for the build-essential cookbook (and its deps) by requiring Chef 14+